### PR TITLE
improvement of gitignore file to stop tracking created files/folders from rmonize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,17 @@
 .Rhistory
 .RData
 .Ruserdata
+
+
+# output documents besides the placeholders
+output/rmonize_report/*
+!output/rmonize_report/placeholder.txt
+
+output/opal_dd/*
+!output/opal_dd/placeholder.txt
+
+output/rmonize_summary/*
+!output/rmonize_summary/placeholder.txt
+
+output/harmonised_dataset/*
+!output/harmonised_dataset/placeholder.txt

--- a/output/opal_dd/placeholder.txt
+++ b/output/opal_dd/placeholder.txt
@@ -1,0 +1,1 @@
+Only Placeholder so that all folders will be tracked by git.

--- a/output/rmonize_summary/placeholder.txt
+++ b/output/rmonize_summary/placeholder.txt
@@ -1,0 +1,1 @@
+Only Placeholder so that all folders will be tracked by git.


### PR DESCRIPTION
- added necessary placeholder.txt files for remaining subfolders of output
- added subfolders to gitignore
- placeholder.txt are exempt from gitignore to keep tracking the higher level folder structure
- Closes #44 